### PR TITLE
fixed wrong median index

### DIFF
--- a/week3/3-Online-Median/README.md
+++ b/week3/3-Online-Median/README.md
@@ -5,7 +5,7 @@ or [C++](median.cpp) which inserts a number to a collection and
 returns the `median` of the collection on each insert.
 
 A `median` of the collection is the element which stays on position
-`ceiling((Length-1)/2)` in the zero-based sorted list of the items.
+`ceiling((Length)/2)` in the zero-based sorted list of the items.
 
 ## Example
 


### PR DESCRIPTION
1 element -> (1 - 1) / 2 = 0
2 elements -> (2 - 1) / 2 = 0

In the example for [5, 6] returns index 1, but should returns 0. So median is at index length / 2
